### PR TITLE
Static library linking of sundials don't have _static suffix anymore

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -333,7 +333,7 @@ fn main() {
 
     for lib_name in &lib_names {
         if cfg!(target_family = "windows") && cfg!(feature = "static_libraries") {
-            println!("cargo:rustc-link-lib=static=sundials_{}_static", lib_name);
+            println!("cargo:rustc-link-lib=static=sundials_{}", lib_name);
         } else {
             println!(
                 "cargo:rustc-link-lib={}=sundials_{}",


### PR DESCRIPTION
compiling sundials with ming64 (MSYS2) toolchain and clang produce no _static suffix sundial libraries, results in failure in static library linking. I think there has been changes on the sundial vendor side such that they don't compile static libraries with suffix _static anymore? Installed toolchain:

- MSYS2
- mingw64 toolchain
- mingw64 clang

...and others that you listed in your pdf.

<img width="892" height="293" alt="image" src="https://github.com/user-attachments/assets/236a0db3-449d-4e59-a916-dc8903939fcf" />
